### PR TITLE
fix -WError=unused issue

### DIFF
--- a/binutils-msp430/PKGBUILD
+++ b/binutils-msp430/PKGBUILD
@@ -58,6 +58,7 @@ build() {
       --infodir=/usr/share/info \
       --libdir=/usr/msp430/lib \
       --mandir=/usr/share/man \
+      --disable-werror \
       --target=msp430
 
   # This checks the host environment and makes sure all the necessary


### PR DESCRIPTION
I had to had this line otherwise I couldn't get it to work.
Furthermore, how is this pkgbuild different from `msp430-elf-binutils`?

Anyway, thanks for your work, I needed those binutils to build TinyOS executables, I'd be pretty lost otherwise.
